### PR TITLE
build: update to jsx transform, drop support for React <17

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "prettier/prettier": "error",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@material-ui/core": "^5.0.0-alpha.33",
-    "react": "^16.8.0 || ^17.0.0"
+    "@material-ui/core": "5.0.0-alpha.33",
+    "react": "^17.0.0"
   },
   "files": [
     "README.md",

--- a/src/ui/EmptyState/EmptyState.tsx
+++ b/src/ui/EmptyState/EmptyState.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import clsx from 'clsx';
 import { useStyles } from './EmptyState.styles';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "allowJs": true,
     "esModuleInterop": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "module": "esnext",
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
Tested on new CRA project with material-ui v5