### PR TITLE
fix(TableCell): disable transition for border-bottom

### DIFF
--- a/packages/react/src/components/Table/TableCell/TableCell.tsx
+++ b/packages/react/src/components/Table/TableCell/TableCell.tsx
@@ -153,7 +153,7 @@ const TableCellContainer = styled('div', {
   overridesResolver: (props, styles) => styles.container
 })(({ theme }) => ({
   borderBottom: `1px solid ${theme.palette.monoA.A100}`,
-  transition: `${theme.transitions.duration.short}ms`,
+  transition: `${theme.transitions.duration.short}ms, border-bottom 0ms`,
   width: '100%',
   height: '100%',
   display: 'flex'


### PR DESCRIPTION

https://github.com/Elonsoft/elonkit-react/assets/137512181/5a6c4bc5-3d97-47ec-843a-d1e2dbad26f9

